### PR TITLE
initial support for cloud hosting / usage by external hosts

### DIFF
--- a/sstvProxy.py
+++ b/sstvProxy.py
@@ -36,7 +36,8 @@
 ###DAMAGE.
 ###
 
-import logging, os, sys, time, argparse, json, gzip, base64, platform, threading, subprocess, urllib, glob, sqlite3, array, socket, struct, ntpath, timeit, re
+import logging, os, sys, time, argparse, json, gzip, base64, platform, threading, subprocess, urllib, glob, sqlite3, \
+	array, socket, struct, ntpath, timeit, re
 
 from datetime import datetime, timedelta
 from json import load, dump
@@ -50,7 +51,7 @@ import datetime as dt
 import xml.sax.saxutils as saxutils
 
 HEADLESS = False
-
+CLOUD = False
 
 try:
 	from urlparse import urljoin
@@ -68,6 +69,7 @@ parser.add_argument("-d", "--debug", action='store_true', help="Console Debuggin
 parser.add_argument("-hl", "--headless", action='store_true', help="Force Headless mode")
 parser.add_argument("-t", "--tvh", action='store_true', help="Force TVH scanning mode")
 parser.add_argument("-i", "--install", action='store_true', help="Force install again")
+parser.add_argument("-c", "--cloud", action='store_true', help='Force cloud hosting mode')
 
 args = parser.parse_args()
 
@@ -79,10 +81,16 @@ except:
 if args.headless or 'headless' in sys.argv:
 	HEADLESS = True
 
+if args.cloud or 'cloud' in sys.argv:
+	CLOUD = True
+
 app = Flask(__name__, static_url_path='')
 
-__version__ = 1.8353
+__version__ = 1.837
 # Changelog
+# 1.837 - Web work
+# 1.836 - Addition of sports.m3u8 which includes groups for current sports
+# 1.8354 - Removal of trailing '==' from URLs.
 # 1.8353 - Fallback fix
 # 1.8352 - Small refactor for sstvLauncher
 # 1.8351 - XML tag fix, xml path fix
@@ -187,7 +195,6 @@ file_handler.setLevel(logging.DEBUG)
 file_handler.setFormatter(log_formatter)
 logger.addHandler(file_handler)
 
-
 USERAGENT = 'YAP - %s - %s - %s' % (sys.argv[0], platform.system(), str(__version__))
 opener = urllib.request.build_opener()
 opener.addheaders = [('User-agent', USERAGENT)]
@@ -225,6 +232,7 @@ class channelinfo:
 	channum = 0
 	channame = ""
 
+
 class programinfo:
 	description = ""
 	channel = 0
@@ -238,13 +246,11 @@ class programinfo:
 	_quality = ""
 	_language = ""
 
-
 	def get_title(self):
 		if len(self._title) == 0:
 			return ("none " + self.timeRange).strip()
 		else:
 			return (self._title + " " + self.quality + " " + self.timeRange).replace("  ", " ").strip()
-
 
 	def set_title(self, title):
 		self._title = title
@@ -252,8 +258,9 @@ class programinfo:
 			if title.startswith("NHL") or "hockey" in title.lower():
 				self._category = "Ice Hockey"
 			elif title.startswith("UEFA") or title.startswith("EPL") or title.startswith(
-					"Premier League") or title.startswith("La Liga") or title.startswith("Bundesliga") or title.startswith(
-					"Serie A") or "soccer" in title.lower():
+					"Premier League") or title.startswith("La Liga") or title.startswith(
+				"Bundesliga") or title.startswith(
+				"Serie A") or "soccer" in title.lower():
 				self._category = "World Football"
 			elif title.startswith("MLB") or "baseball" in title.lower():
 				self._category = "Baseball"
@@ -267,7 +274,7 @@ class programinfo:
 				self._category = "Wrestling"
 			elif title.startswith("NFL") or title.startswith("NBA"):
 				self._category = title.split(" ")[0].replace(":", "").strip()
-			elif 'nba' in title.lower() or 'nbl' in title.lower() or 'ncaam' in title.lower()or 'basketball' in title.lower():
+			elif 'nba' in title.lower() or 'nbl' in title.lower() or 'ncaam' in title.lower() or 'basketball' in title.lower():
 				self._category = "Basketball"
 			elif 'nfl' in title.lower() or 'football' in title.lower() or 'american football' in title.lower() or 'ncaaf' in title.lower() or 'cfb' in title.lower():
 				self._category = "Football"
@@ -292,19 +299,14 @@ class programinfo:
 			elif 'news' in title.lower():
 				self._category = "News"
 
-			# print(title,",", self._category)
-
-
 	title = property(get_title, set_title)
-
 
 	def get_category(self):
 		if (len(self._category) == 0 or self._category == "none") and (
-			self.title.lower().find("news") or self.description.lower().find("news")) > -1:
+				self.title.lower().find("news") or self.description.lower().find("news")) > -1:
 			return "News"
 		else:
 			return self._category
-
 
 	def set_category(self, category):
 		if category == "tv":
@@ -312,13 +314,10 @@ class programinfo:
 		else:
 			self._category = category
 
-
 	category = property(get_category, set_category)
-
 
 	def get_language(self):
 		return self._language
-
 
 	def set_language(self, language):
 		if language.upper() == "US" or language.upper() == "EN":
@@ -326,13 +325,10 @@ class programinfo:
 		else:
 			self._language = language.upper()
 
-
 	language = property(get_language, set_language)
-
 
 	def get_quality(self):
 		return self._quality
-
 
 	def set_quality(self, quality):
 		if quality.endswith("x1080"):
@@ -351,21 +347,17 @@ class programinfo:
 			self._quality = quality
 			self.height = 0
 
-
 	quality = property(get_quality, set_quality)
-
 
 	def get_album(self):
 		if self._quality.upper() == "HQLQ" and self.channelname.upper().find(" 720P") > -1:
 			self._quality = "720p"
 		return (self._category + " " + self.quality + " " + self._language).strip().replace("  ", " ")
 
-
 	album = property(get_album)
 
 
 class EST5EDT(dt.tzinfo):
-
 	def utcoffset(self, dt):
 		return timedelta(hours=-5) + self.dst(dt)
 
@@ -384,6 +376,8 @@ class EST5EDT(dt.tzinfo):
 
 	def tzname(self, dt):
 		return 'EST5EDT'
+
+
 ############################################################
 # CONFIG
 ############################################################
@@ -421,7 +415,7 @@ TVHPASS = ''
 OVRXML = ''
 tvhWeight = 300  # subscription priority
 tvhstreamProfile = 'pass'  # specifiy a stream profile that you want to use for adhoc transcoding in tvh, e.g. mp4
-GUIDELOOKAHEAD = 5 #minutes
+GUIDELOOKAHEAD = 5  # minutes
 PIPE = False
 CHANAPI = None
 FALLBACK = False
@@ -490,7 +484,29 @@ serverList = [
 	['   Asia-Old', 'dsg']
 ]
 
-vaders_channels = {"1":"2499","2":"2500","3":"2501","4":"2502","5":"2503","6":"2504","7":"2505","8":"2506","9":"2507","10":"2508","11":"2509","12":"2510","13":"2511","14":"2512","15":"2513","16":"2514","17":"2515","18":"2516","19":"2517","20":"2518","21":"2519","22":"2520","23":"2521","24":"2522","25":"2523","26":"2524","27":"2525","28":"2526","29":"2527","30":"2528","31":"2529","32":"2530","33":"2531","34":"2532","35":"2533","36":"2534","37":"2535","38":"2536","39":"2537","40":"2538","41":"2541","42":"2542","43":"2543","44":"2544","45":"2545","46":"2546","47":"2547","48":"2548","49":"2549","50":"2550","51":"2551","52":"2552","53":"2553","54":"2554","55":"2555","56":"2556","57":"2557","58":"2606","59":"2607","60":"2608","61":"2609","62":"2610","63":"2611","64":"2612","65":"2613","66":"2614","67":"2615","68":"2616","69":"2617","70":"2618","71":"2619","72":"2620","73":"2622","74":"2621","75":"2623","76":"2624","77":"2625","78":"2626","79":"2627","80":"2628","81":"2629","82":"2630","83":"2631","84":"2632","85":"2633","86":"2634","87":"2635","88":"2636","89":"2637","90":"2638","91":"2639","92":"2640","93":"2641","94":"2642","95":"2643","96":"2644","97":"2645","98":"2646","99":"2647","100":"2648","101":"2649","102":"2650","103":"2651","104":"2652","105":"2653","106":"2654","107":"2655","108":"2656","109":"2657","110":"2658","111":"2659","112":"2660","113":"2661","114":"2662","115":"2663","116":"2664","117":"2665","118":"2666","119":"2667","120":"2668","121":"47381","122":"2679","123":"2680","124":"2681","125":"2682","126":"47376","127":"47377","128":"47378","129":"47379","130":"47380","131":"47718","132":"47719","133":"49217","134":"50314","135":"50315","136":"50319","137":"50320","138":"50321","139":"50322","141":"49215","140":"50394","142":"49216","143":"50395","144":"50396","145":"50397","146":"50398","147":"50399","148":"47707","149":"47670","150":"47716"}
+vaders_channels = {"1": "2499", "2": "2500", "3": "2501", "4": "2502", "5": "2503", "6": "2504", "7": "2505",
+				   "8": "2506", "9": "2507", "10": "2508", "11": "2509", "12": "2510", "13": "2511", "14": "2512",
+				   "15": "2513", "16": "2514", "17": "2515", "18": "2516", "19": "2517", "20": "2518", "21": "2519",
+				   "22": "2520", "23": "2521", "24": "2522", "25": "2523", "26": "2524", "27": "2525", "28": "2526",
+				   "29": "2527", "30": "2528", "31": "2529", "32": "2530", "33": "2531", "34": "2532", "35": "2533",
+				   "36": "2534", "37": "2535", "38": "2536", "39": "2537", "40": "2538", "41": "2541", "42": "2542",
+				   "43": "2543", "44": "2544", "45": "2545", "46": "2546", "47": "2547", "48": "2548", "49": "2549",
+				   "50": "2550", "51": "2551", "52": "2552", "53": "2553", "54": "2554", "55": "2555", "56": "2556",
+				   "57": "2557", "58": "2606", "59": "2607", "60": "2608", "61": "2609", "62": "2610", "63": "2611",
+				   "64": "2612", "65": "2613", "66": "2614", "67": "2615", "68": "2616", "69": "2617", "70": "2618",
+				   "71": "2619", "72": "2620", "73": "2622", "74": "2621", "75": "2623", "76": "2624", "77": "2625",
+				   "78": "2626", "79": "2627", "80": "2628", "81": "2629", "82": "2630", "83": "2631", "84": "2632",
+				   "85": "2633", "86": "2634", "87": "2635", "88": "2636", "89": "2637", "90": "2638", "91": "2639",
+				   "92": "2640", "93": "2641", "94": "2642", "95": "2643", "96": "2644", "97": "2645", "98": "2646",
+				   "99": "2647", "100": "2648", "101": "2649", "102": "2650", "103": "2651", "104": "2652",
+				   "105": "2653", "106": "2654", "107": "2655", "108": "2656", "109": "2657", "110": "2658",
+				   "111": "2659", "112": "2660", "113": "2661", "114": "2662", "115": "2663", "116": "2664",
+				   "117": "2665", "118": "2666", "119": "2667", "120": "2668", "121": "47381", "122": "2679",
+				   "123": "2680", "124": "2681", "125": "2682", "126": "47376", "127": "47377", "128": "47378",
+				   "129": "47379", "130": "47380", "131": "47718", "132": "47719", "133": "49217", "134": "50314",
+				   "135": "50315", "136": "50319", "137": "50320", "138": "50321", "139": "50322", "141": "49215",
+				   "140": "50394", "142": "49216", "143": "50395", "144": "50396", "145": "50397", "146": "50398",
+				   "147": "50399", "148": "47707", "149": "47670", "150": "47716"}
 
 providerList = [
 	['Live247', 'view247'],
@@ -509,14 +525,15 @@ qualityList = [
 ]
 
 STREAM_INFO = {'hls': {'domain': 'https', 'port': '443', 'playlist': '.stream/playlist.m3u8', 'quality': 'standard'},
-   'hlsa': {'domain': 'https', 'port': '443', 'playlist': '/playlist.m3u8', 'quality': '.smil'},
-   'rtmp': {'domain': 'rtmp', 'port': '3625', 'playlist': '.stream', 'quality': 'standard'},
-   'mpegts': {'domain': 'https', 'port': '443', 'playlist': '.stream/mpeg.2ts', 'quality': 'standard'},
-   'rtsp': {'domain': 'rtsp', 'port': '2935', 'playlist': '.stream', 'quality': 'standard'},
-   'dash': {'domain': 'https', 'port': '443', 'playlist': '/manifest.mpd', 'quality': '.smil'},
-   'wss': {'domain': 'wss', 'port': '443', 'playlist': '.stream', 'quality': 'standard'},
-   'wssa': {'domain': 'wss', 'port': '443', 'playlist': '', 'quality': '.smil'}
-               }
+			   'hlsa': {'domain': 'https', 'port': '443', 'playlist': '/playlist.m3u8', 'quality': '.smil'},
+			   'rtmp': {'domain': 'rtmp', 'port': '3625', 'playlist': '.stream', 'quality': 'standard'},
+			   'mpegts': {'domain': 'https', 'port': '443', 'playlist': '.stream/mpeg.2ts', 'quality': 'standard'},
+			   'rtsp': {'domain': 'rtsp', 'port': '2935', 'playlist': '.stream', 'quality': 'standard'},
+			   'dash': {'domain': 'https', 'port': '443', 'playlist': '/manifest.mpd', 'quality': '.smil'},
+			   'wss': {'domain': 'wss', 'port': '443', 'playlist': '.stream', 'quality': 'standard'},
+			   'wssa': {'domain': 'wss', 'port': '443', 'playlist': '', 'quality': '.smil'}
+			   }
+
 
 def adv_settings():
 	if os.path.isfile(os.path.join(os.path.dirname(sys.argv[0]), 'advancedsettings.json')):
@@ -585,9 +602,8 @@ def adv_settings():
 				PIPE = advconfig["pipe"] == "True"
 
 
-
 def load_settings():
-	global QUAL, QUALLIMIT, USER, PASS, SRVR,SRVR_SPARE, SITE, STRM, KODIPORT, LISTEN_IP, LISTEN_PORT, SERVER_HOST, EXTIP, EXT_HOST, EXTPORT
+	global QUAL, QUALLIMIT, USER, PASS, SRVR, SRVR_SPARE, SITE, STRM, KODIPORT, LISTEN_IP, LISTEN_PORT, SERVER_HOST, EXTIP, EXT_HOST, EXTPORT
 	if not os.path.isfile(os.path.join(os.path.dirname(sys.argv[0]), 'proxysettings.json')):
 		logger.debug("No config file found.")
 	try:
@@ -692,8 +708,6 @@ def load_settings():
 	adv_settings()
 	if args.install:
 		installer()
-
-
 
 
 ############################################################
@@ -963,10 +977,10 @@ if not HEADLESS:
 				self.sub_frame.forget()
 				self.toggle_button.configure(text='+')
 
+
 	class GUI(tkinter.Frame):
 		def client_exit(self, root):
 			root.destroy()
-
 
 		def __init__(self, master):
 			tkinter.Frame.__init__(self, master)
@@ -1020,7 +1034,7 @@ if not HEADLESS:
 
 			userServer = tkinter.StringVar()
 			userServer.set('Auto')
-			self.server = tkinter.OptionMenu(t2.sub_frame, userServer,  *['Auto'] + [x[0] for x in serverList])
+			self.server = tkinter.OptionMenu(t2.sub_frame, userServer, *['Auto'] + [x[0] for x in serverList])
 			self.server.grid(row=1, column=2)
 
 			self.labelStream = tkinter.StringVar()
@@ -1163,10 +1177,10 @@ if not HEADLESS:
 				with open(os.path.join(os.path.dirname(sys.argv[0]), 'proxysettings.json'), 'w') as fp:
 					dump(config, fp)
 
-
-
 				self.labelSetting1 = tkinter.StringVar()
-				self.labelSetting1.set("Open a web browser and go to %s for instructions and output URLs." % urljoin(SERVER_HOST, SERVER_PATH))
+				self.labelSetting1.set(
+					"Open a web browser and go to %s for instructions and output URLs." % urljoin(SERVER_HOST,
+																								  SERVER_PATH))
 				labelSetting1 = tkinter.Label(master, textvariable=self.labelSetting1, height=2)
 				labelSetting1.grid(row=1)
 
@@ -1181,8 +1195,6 @@ if not HEADLESS:
 
 			button1 = tkinter.Button(master, text="Submit", width=20, command=lambda: gather())
 			button1.grid(row=7, column=1, columnspan=3)
-
-
 
 ############################################################
 # MISC
@@ -1222,14 +1234,16 @@ def dl_icons(channum):
 	logger.debug("Downloading icons")
 	icontemplate = 'https://guide.smoothstreams.tv/assets/images/channels/{0}.png'
 	# create blank icon
-	urllib.request.urlretrieve(icontemplate.format(150), os.path.join(os.path.dirname(sys.argv[0]), 'cache', 'empty.png'))
+	urllib.request.urlretrieve(icontemplate.format(150),
+							   os.path.join(os.path.dirname(sys.argv[0]), 'cache', 'empty.png'))
 	for i in range(1, channum + 1):
 		name = str(i) + '.png'
 		try:
-			urllib.request.urlretrieve(icontemplate.format(i), os.path.join(os.path.dirname(sys.argv[0]), 'cache', name))
+			urllib.request.urlretrieve(icontemplate.format(i),
+									   os.path.join(os.path.dirname(sys.argv[0]), 'cache', name))
 		except:
 			continue
-		# logger.debug("No icon for channel:%s"% i)
+	# logger.debug("No icon for channel:%s"% i)
 	logger.debug("Icon download completed.")
 
 
@@ -1289,6 +1303,7 @@ def averageList(lst):
 			logger.debug("Couldn't convert %s to float" % repr(p))
 	return avg_ping / avg_ping_cnt
 
+
 def testServers(update_settings=True):
 	# todo
 	global SRVR, SRVR_SPARE, AUTO_SERVER
@@ -1307,7 +1322,8 @@ def testServers(update_settings=True):
 		logger.info('Testing servers... %s' % name)
 		ping_results = False
 		try:
-			url = "https://" + host + ".SmoothStreams.tv:443/"+ SITE + "/ch01q1.stream/playlist.m3u8?wmsAuthSign=" + token['hash']
+			url = "https://" + host + ".SmoothStreams.tv:443/" + SITE + "/ch01q1.stream/playlist.m3u8?wmsAuthSign=" + \
+				  token['hash']
 			logger.debug('Testing url %s' % url)
 			# if platform.system() == 'Windows':
 			# 	p = subprocess.Popen(["ping", "-n", "4", url], stdout=subprocess.PIPE,
@@ -1355,11 +1371,12 @@ def testServers(update_settings=True):
 	logger.debug("Failed to access servers: %s" % fails)
 	return res
 
+
 def findChannelURL(input_url=None, qual='1', target_serv=SRVR, fail=0):
 	# todo, rtmp
 	global SRVR
 	service = SRVR
-	qlist = [qual] #, '1', '2', '3']
+	qlist = [qual]  # , '1', '2', '3']
 	res = None
 	ping = False
 	for q in range(len(qlist)):
@@ -1367,9 +1384,9 @@ def findChannelURL(input_url=None, qual='1', target_serv=SRVR, fail=0):
 			continue
 		options = []
 		if target_serv.startswith('dna') and fail != 2:
-			if 'dnaw' in target_serv and fail ==0:
+			if 'dnaw' in target_serv and fail == 0:
 				options = [(name, host) for (name, host) in serverList if host.startswith('dnaw')]
-			elif 'dnae' in target_serv and fail ==0:
+			elif 'dnae' in target_serv and fail == 0:
 				options = [(name, host) for (name, host) in serverList if host.startswith('dnae')]
 			else:
 				options = [(name, host) for (name, host) in serverList if host.startswith('dna')]
@@ -1425,9 +1442,11 @@ def findChannelURL(input_url=None, qual='1', target_serv=SRVR, fail=0):
 		return res
 	logger.info("Failed to find that channel on a similar quality or server")
 	if fail < 2:
-		return findChannelURL(input_url, qual='1', fail=fail+1)
+		return findChannelURL(input_url, qual='1', fail=fail + 1)
 	logger.info("Failed to find that channel on any quality or server")
 	return input_url
+
+
 def launch_browser():
 	try:
 		import webbrowser
@@ -1451,39 +1470,40 @@ def dl_epg(source=1):
 		target_utc_hr = (cur_utc_hr // 4) * 4
 		target_utc_datetime = datetime.utcnow().replace(microsecond=0, second=0, minute=0, hour=target_utc_hr)
 		logger.debug("utc time is: %s,    utc target time is: %s,    file time is: %s" % (
-		datetime.utcnow(), target_utc_datetime, datetime.utcfromtimestamp(os.stat(existing).st_mtime)))
+			datetime.utcnow(), target_utc_datetime, datetime.utcfromtimestamp(os.stat(existing).st_mtime)))
 		if os.path.isfile(existing) and os.stat(existing).st_mtime > target_utc_datetime.timestamp():
 			logger.debug("Skipping download of epg")
 			return
 	to_process = []
 	# override the xml with one of your own
 
-
 	if source == 1:
 		if OVRXML != '':
 			if OVRXML.startswith('http://') or OVRXML.startswith('https://'):
 				if OVRXML.endswith('.gz') or OVRXML.endswith('.gz?raw=1'):
-					urllib.request.urlretrieve(OVRXML, os.path.join(os.path.dirname(sys.argv[0]), 'cache', 'rawovrepg.xml.gz'))
+					urllib.request.urlretrieve(OVRXML,
+											   os.path.join(os.path.dirname(sys.argv[0]), 'cache', 'rawovrepg.xml.gz'))
 					unzipped = os.path.join(os.path.dirname(sys.argv[0]), 'cache', 'rawovrepg.xml.gz')
 				else:
-					urllib.request.urlretrieve(OVRXML, os.path.join(os.path.dirname(sys.argv[0]), 'cache', 'rawovrepg.xml'))
+					urllib.request.urlretrieve(OVRXML,
+											   os.path.join(os.path.dirname(sys.argv[0]), 'cache', 'rawovrepg.xml'))
 					unzipped = os.path.join(os.path.dirname(sys.argv[0]), 'cache', 'rawovrepg.xml')
 			else:
 				unzipped = OVRXML
 		else:
 			logger.info("Downloading epg")
 			urllib.request.urlretrieve("https://fast-guide.smoothstreams.tv/altepg/xmltv5.xml.gz",
-								 os.path.join(os.path.dirname(sys.argv[0]), 'cache', 'rawepg.xml.gz'))
+									   os.path.join(os.path.dirname(sys.argv[0]), 'cache', 'rawepg.xml.gz'))
 			unzipped = os.path.join(os.path.dirname(sys.argv[0]), 'cache', 'rawepg.xml.gz')
 		to_process.append([unzipped, "epg.xml", 'fog' if OVRXML == '' else 'ovr'])
 		urllib.request.urlretrieve("https://fast-guide.smoothstreams.tv/feed.xml",
-							 os.path.join(os.path.dirname(sys.argv[0]), 'cache', 'rawsports.xml'))
+								   os.path.join(os.path.dirname(sys.argv[0]), 'cache', 'rawsports.xml'))
 		unzippedsports = os.path.join(os.path.dirname(sys.argv[0]), 'cache', 'rawsports.xml')
 		to_process.append([unzippedsports, "sports.xml", 'sstv'])
 	else:
 		logger.info("Downloading sstv epg")
 		urllib.request.urlretrieve("https://fast-guide.smoothstreams.tv/feed.xml",
-							 os.path.join(os.path.dirname(sys.argv[0]), 'cache', 'rawepg.xml'))
+								   os.path.join(os.path.dirname(sys.argv[0]), 'cache', 'rawepg.xml'))
 		unzipped = os.path.join(os.path.dirname(sys.argv[0]), 'cache', 'rawepg.xml')
 		to_process.append([unzipped, "epg.xml", 'sstv'])
 		to_process.append([unzipped, "sports.xml", 'sstv'])
@@ -1498,18 +1518,18 @@ def dl_epg(source=1):
 			root = source.getroot()
 			changelist = {}
 
-			with open(os.path.join(os.path.dirname(sys.argv[0]), 'cache','prep.xml'), 'w+') as f:
+			with open(os.path.join(os.path.dirname(sys.argv[0]), 'cache', 'prep.xml'), 'w+') as f:
 				f.write('<?xml version="1.0" encoding="UTF-8"?>'.rstrip('\r\n'))
-				f.write('''<tv><channel id="static_refresh"><display-name lang="en">Static Refresh</display-name><icon src="http://speed.guide.smoothstreams.tv/assets/images/channels/150.png" /></channel><programme channel="static_refresh" start="20170118213000 +0000" stop="20201118233000 +0000"><title lang="us">Press to refresh rtmp channels</title><desc lang="en">Select this channel in order to refresh the RTMP playlist. Only use from the channels list and NOT the guide page. Required every 4hrs.</desc><category lang="us">Other</category><episode-num system="">1</episode-num></programme></tv>''')
-			desttree = ET.parse(os.path.join(os.path.dirname(sys.argv[0]), 'cache','prep.xml'))
+				f.write(
+					'''<tv><channel id="static_refresh"><display-name lang="en">Static Refresh</display-name><icon src="http://speed.guide.smoothstreams.tv/assets/images/channels/150.png" /></channel><programme channel="static_refresh" start="20170118213000 +0000" stop="20201118233000 +0000"><title lang="us">Press to refresh rtmp channels</title><desc lang="en">Select this channel in order to refresh the RTMP playlist. Only use from the channels list and NOT the guide page. Required every 4hrs.</desc><category lang="us">Other</category><episode-num system="">1</episode-num></programme></tv>''')
+			desttree = ET.parse(os.path.join(os.path.dirname(sys.argv[0]), 'cache', 'prep.xml'))
 			desttreeroot = desttree.getroot()
-
 
 			for channel in source.iter('channel'):
 				if process[2] == 'fog':
 					b = channel.find('display-name')
 					newname = [chan_map[x].channum for x in range(len(chan_map) + 1) if
-					           x != 0 and chan_map[x].epg == channel.attrib['id'] and chan_map[x].channame == b.text]
+							   x != 0 and chan_map[x].epg == channel.attrib['id'] and chan_map[x].channame == b.text]
 					if len(newname) > 1:
 						logger.debug("EPG rename conflict %s" % ",".join(newname))
 					# It's a list regardless of length so first item is always wanted.
@@ -1528,7 +1548,6 @@ def dl_epg(source=1):
 						logger.info("A programme was skipped as it couldn't be assigned to a channel, refer log.")
 						logger.debug(programme.find('title').text, programme.attrib)
 
-
 				desc = programme.find('desc')
 				if desc is None:
 					ET.SubElement(programme, 'desc')
@@ -1539,7 +1558,6 @@ def dl_epg(source=1):
 				else:
 					desc.text = saxutils.escape(str(desc.text))
 
-
 				sub = programme.find('sub-title')
 				if sub is None:
 					ET.SubElement(programme, 'sub-title')
@@ -1548,11 +1566,8 @@ def dl_epg(source=1):
 				else:
 					sub.text = saxutils.escape(str(sub.text))
 
-
 				title = programme.find('title')
 				title.text = saxutils.escape(str(title.text))
-
-
 
 				cat = programme.find('category')
 				if cat is None:
@@ -1565,31 +1580,39 @@ def dl_epg(source=1):
 				# emby
 				# sports|basketball|baseball|football|Rugby|Soccer|Cricket|Tennis/Squash|Motor Sport|Golf|Martial Sports|Ice Hockey|Alpine Sports|Darts
 				if cat.text == "Sports":
-					if any(sport in title.text.lower() for sport in ['nba','ncaam','nba','basquetebol','wnba','g-league']):
+					if any(sport in title.text.lower() for sport in
+						   ['nba', 'ncaam', 'nba', 'basquetebol', 'wnba', 'g-league']):
 						cat.text = "Basketball"
-					elif any(sport in title.text.lower() for sport in ['nfl','football','american football','ncaaf','cfb']):
+					elif any(sport in title.text.lower() for sport in
+							 ['nfl', 'football', 'american football', 'ncaaf', 'cfb']):
 						cat.text = "Football"
-					elif any(sport in title.text.lower() for sport in ['epl','efl','fa cup','spl','taca de portugal','w-league','soccer','ucl','coupe de la ligue','league cup','mls','uefa','fifa','fc','la liga','serie a','wcq','khl:','shl:','1.bl:','euroleague','knvb','superliga turca','liga holandesa']):
+					elif any(sport in title.text.lower() for sport in
+							 ['epl', 'efl', 'fa cup', 'spl', 'taca de portugal', 'w-league', 'soccer', 'ucl',
+							  'coupe de la ligue', 'league cup', 'mls', 'uefa', 'fifa', 'fc', 'la liga', 'serie a',
+							  'wcq', 'khl:', 'shl:', '1.bl:', 'euroleague', 'knvb', 'superliga turca',
+							  'liga holandesa']):
 						cat.text = "Soccer"
-					elif any(sport in title.text.lower() for sport in ['rugby','nrl','afl','rfu','french top 14:',"women's premier 15",'guinness pro14']):
+					elif any(sport in title.text.lower() for sport in
+							 ['rugby', 'nrl', 'afl', 'rfu', 'french top 14:', "women's premier 15", 'guinness pro14']):
 						cat.text = "Rugby"
-					elif any(sport in title.text.lower() for sport in ['cricket','t20','t20i']):
+					elif any(sport in title.text.lower() for sport in ['cricket', 't20', 't20i']):
 						cat.text = "Cricket"
-					elif any(sport in title.text.lower() for sport in ['tennis','squash','atp']):
+					elif any(sport in title.text.lower() for sport in ['tennis', 'squash', 'atp']):
 						cat.text = "Tennis/Squash"
-					elif any(sport in title.text.lower() for sport in ['f1','nascar','motogp','racing']):
+					elif any(sport in title.text.lower() for sport in ['f1', 'nascar', 'motogp', 'racing']):
 						cat.text = "Motor Sport"
-					elif any(sport in title.text.lower() for sport in ['golf','pga']):
+					elif any(sport in title.text.lower() for sport in ['golf', 'pga']):
 						cat.text = "Golf"
-					elif any(sport in title.text.lower() for sport in ['boxing','mma','ufc','wrestling','wwe']):
+					elif any(sport in title.text.lower() for sport in ['boxing', 'mma', 'ufc', 'wrestling', 'wwe']):
 						cat.text = "Martial Sports"
-					elif any(sport in title.text.lower() for sport in ['hockey','nhl','ice hockey','iihf']):
+					elif any(sport in title.text.lower() for sport in ['hockey', 'nhl', 'ice hockey', 'iihf']):
 						cat.text = "Ice Hockey"
-					elif any(sport in title.text.lower() for sport in ['baseball','mlb','beisbol','minor league','ncaab']):
+					elif any(sport in title.text.lower() for sport in
+							 ['baseball', 'mlb', 'beisbol', 'minor league', 'ncaab']):
 						cat.text = "Baseball"
 					elif any(sport in title.text.lower() for sport in ['news']):
 						cat.text = "News"
-					elif any(sport in title.text.lower() for sport in ['alpine','skiing','snow']):
+					elif any(sport in title.text.lower() for sport in ['alpine', 'skiing', 'snow']):
 						cat.text = "Alpine Sports"
 					elif any(sport in title.text.lower() for sport in ['darts']):
 						cat.text = "Darts"
@@ -1602,9 +1625,6 @@ def dl_epg(source=1):
 			# 	f.seek(0, 0)
 			# 	f.write('<?xml version="1.0" encoding="UTF-8"?>'.rstrip('\r\n') + content)
 			# return
-
-
-
 
 			desttree.write(os.path.join(os.path.dirname(sys.argv[0]), 'cache', process[1]))
 			logger.debug("writing to %s" % process[1])
@@ -1634,7 +1654,7 @@ def dl_sstv_epg():
 		target_utc_hr = (cur_utc_hr // 3) * 3
 		target_utc_datetime = datetime.utcnow().replace(microsecond=0, second=0, minute=0, hour=target_utc_hr)
 		logger.debug("utc time is: %s,    utc target time is: %s,    file time is: %s" % (
-		datetime.utcnow(), target_utc_datetime, datetime.utcfromtimestamp(os.stat(existing).st_mtime)))
+			datetime.utcnow(), target_utc_datetime, datetime.utcfromtimestamp(os.stat(existing).st_mtime)))
 		if os.path.isfile(existing) and os.stat(existing).st_mtime > target_utc_datetime.timestamp():
 			logger.debug("Skipping download of epg")
 			return
@@ -1725,19 +1745,23 @@ def json2xml(json_obj):
 	mtree.write(os.path.join(os.path.dirname(sys.argv[0]), 'cache', 'sstv_full.xml'))
 	return
 
-def getProgram(channel):
+
+def getProgram(channel, sports=False):
 	global jsonGuide1, jsonGuide2
 	tmNow = time.localtime(time.time() + GUIDELOOKAHEAD * 60)
 	sched_offest = EST5EDT().utc_seconds()
 	retVal = programinfo()
-	local_off = datetime.utcoffset(datetime.utcnow().replace(tzinfo=dt.timezone.utc).astimezone(tz=None)).total_seconds()
+	local_off = datetime.utcoffset(
+		datetime.utcnow().replace(tzinfo=dt.timezone.utc).astimezone(tz=None)).total_seconds()
 	if str(int(channel)) in jsonGuide1:
 		oChannel = jsonGuide1[str(int(channel))]
 		retVal.channel = channel
 		retVal.channelname = oChannel["name"].replace(format(channel, "02") + " - ", "").strip()
 		for item in oChannel["items"]:
-			startTime = time.localtime(time.mktime(datetime.strptime(item["time"], '%Y-%m-%d %H:%M:%S').timetuple()) - sched_offest + local_off)
-			endTime = time.localtime(time.mktime(datetime.strptime(item["end_time"], '%Y-%m-%d %H:%M:%S').timetuple()) - sched_offest + local_off)
+			startTime = time.localtime(time.mktime(
+				datetime.strptime(item["time"], '%Y-%m-%d %H:%M:%S').timetuple()) - sched_offest + local_off)
+			endTime = time.localtime(time.mktime(
+				datetime.strptime(item["end_time"], '%Y-%m-%d %H:%M:%S').timetuple()) - sched_offest + local_off)
 			if startTime < tmNow and endTime > tmNow:
 				retVal.category = item["category"].strip()
 				retVal.quality = item["quality"].upper()
@@ -1749,7 +1773,7 @@ def getProgram(channel):
 				retVal.endTime = endTime
 				retVal.timeRange = time.strftime("%H:%M", startTime) + "-" + time.strftime("%H:%M", endTime)
 				return retVal
-	if str(int(channel)) in jsonGuide2:
+	if not sports and str(int(channel)) in jsonGuide2:
 		oChannel = jsonGuide2[str(int(channel))]
 		retVal.channel = channel
 		retVal.channelname = oChannel["name"].replace(format(channel, "02") + " - ", "").strip()
@@ -1797,6 +1821,7 @@ def getJSON(sFile, sURL, sURL2):
 		pass
 
 	return retVal
+
 
 ############################################################
 # SSTV
@@ -1863,7 +1888,6 @@ def build_channel_map():
 
 	for item in jsonChanList:
 		retVal = channelinfo()
-		# print(item)
 		oChannel = jsonChanList[item]
 		retVal.channum = oChannel["channum"]
 		channel = int(oChannel["channum"])
@@ -1887,7 +1911,6 @@ def build_channel_map_sstv():
 
 	for item in jsonEPG:
 		retVal = channelinfo()
-		# print(item)
 		oChannel = jsonEPG[item]
 		retVal.channum = oChannel["number"]
 		channel = int(oChannel["number"])
@@ -1902,7 +1925,7 @@ def build_channel_map_sstv():
 	return chan_map
 
 
-def build_playlist(host, strmType = None):
+def build_playlist(host, strmType=None):
 	# standard dynamic playlist
 	global chan_map
 	if not strmType or strmType not in streamtype: strmType = STRM
@@ -1920,7 +1943,7 @@ def build_playlist(host, strmType = None):
 				tokenDict = {"username": "vsmystreams_" + USER, "password": PASS}
 				jsonToken = json.dumps(tokenDict)
 				tokens = base64.b64encode(jsonToken.encode('utf-8'))
-				strm = 'ts'  if STRM == 'mpegts' else 'm3u8'
+				strm = 'ts' if STRM == 'mpegts' else 'm3u8'
 				tokens = urllib.parse.urlencode({"token": str(tokens)[1:]})
 				channel_url = vaders_url.format(vaders_channels[str(pos)], strm) + tokens
 			else:
@@ -1940,35 +1963,62 @@ def build_playlist(host, strmType = None):
 
 	return new_playlist
 
+
+def build_sports_playlist(host, strmType=None):
+	global chan_map
+	if not strmType or strmType not in streamtype: strmType = STRM
+	new_playlist = "#EXTM3U x-tvg-url='%s/epg.xml'\n" % urljoin(host, SERVER_PATH)
+	for pos in range(1, len(chan_map) + 1):
+		try:
+			prog = getProgram(pos, sports=True)
+			# build channel url
+			url = "{0}/playlist.m3u8?ch={1}&strm={2}&qual={3}"
+			if strmType == 'mpegts':
+				url = "{0}/mpeg.2ts?ch={1}&strm={2}&qual={3}"
+			urlformatted = url.format(SERVER_PATH, chan_map[pos].channum, strmType, QUAL)
+			channel_url = urljoin(host, urlformatted)
+			# build playlist entry
+			group = prog.category
+			new_playlist += '#EXTINF:-1 tvg-id="%s" tvg-name="%s" tvg-logo="%s/%s/%s.png" channel-id="%s" group-title="%s",%s\n' % (
+				chan_map[pos].channum, chan_map[pos].channame, host, SERVER_PATH, chan_map[pos].channum,
+				chan_map[pos].channum, group, chan_map[pos].channame)
+			new_playlist += '%s\n' % channel_url
+
+		except:
+			logger.exception("Channel #%s failed. Channel missing from Fog's channels.json" % pos)
+	logger.info("Built Dynamic playlist")
+
+	return new_playlist
+
+
 def build_xspf(host, request_file):
 	# standard dynamic playlist
 	global chan_map
 
 	xspfBodyTemplate = ('<?xml version="1.0" encoding="UTF-8"?>\n' +
-		 '<playlist xmlns="http://xspf.org/ns/0/" xmlns:vlc="http://www.videolan.org/vlc/playlist/ns/0/" version="1">\n' +
-		'\t<title>Playlist</title>\n' +
-		'\t<trackList>\n' +
-		'{0}' +
-		'\t</trackList>\n' +
-		'\t<extension application="http://www.videolan.org/vlc/playlist/0">\n' +
-		'{1}' +
-		'\t</extension>\n' +
-		'</playlist>')
+						'<playlist xmlns="http://xspf.org/ns/0/" xmlns:vlc="http://www.videolan.org/vlc/playlist/ns/0/" version="1">\n' +
+						'\t<title>Playlist</title>\n' +
+						'\t<trackList>\n' +
+						'{0}' +
+						'\t</trackList>\n' +
+						'\t<extension application="http://www.videolan.org/vlc/playlist/0">\n' +
+						'{1}' +
+						'\t</extension>\n' +
+						'</playlist>')
 	xspfTrackTemplate = ('\t\t<track>\n' +
-		'\t\t\t<location>{5}</location>\n' +
-		'\t\t\t<title>{3}</title>\n' +
-		'\t\t\t<creator>{8}</creator>\n' +
-		'\t\t\t<album>{0}</album>\n' +
-		'\t\t\t<trackNum>{6}</trackNum>\n' +
-		'\t\t\t<annotation>{9}</annotation>\n' +
-		'\t\t\t<extension application="http://www.videolan.org/vlc/playlist/0">\n' +
-		'\t\t\t\t<vlc:id>{7}</vlc:id>\n' +
-		'\t\t\t</extension>\n' +
-		'\t\t</track>\n')
+						 '\t\t\t<location>{5}</location>\n' +
+						 '\t\t\t<title>{3}</title>\n' +
+						 '\t\t\t<creator>{8}</creator>\n' +
+						 '\t\t\t<album>{0}</album>\n' +
+						 '\t\t\t<trackNum>{6}</trackNum>\n' +
+						 '\t\t\t<annotation>{9}</annotation>\n' +
+						 '\t\t\t<extension application="http://www.videolan.org/vlc/playlist/0">\n' +
+						 '\t\t\t\t<vlc:id>{7}</vlc:id>\n' +
+						 '\t\t\t</extension>\n' +
+						 '\t\t</track>\n')
 	xspfTrack2Template = '\t\t<vlc:item tid="{0}"/>\n'
 	xspfTracks = ""
 	xspfTracks2 = ""
-
 
 	# build playlist using the data we have
 	for pos in range(1, len(chan_map) + 1):
@@ -1982,7 +2032,7 @@ def build_xspf(host, request_file):
 			tokenDict = {"username": "vsmystreams_" + USER, "password": PASS}
 			jsonToken = json.dumps(tokenDict)
 			tokens = base64.b64encode(jsonToken.encode('utf-8'))
-			strm = 'ts'  if STRM == 'mpegts' else 'm3u8'
+			strm = 'ts' if STRM == 'mpegts' else 'm3u8'
 			tokens = urllib.parse.urlencode({"token": str(tokens)[1:]})
 			channel_url = vaders_url.format(vaders_channels[str(pos)], strm) + tokens
 		else:
@@ -1991,17 +2041,17 @@ def build_xspf(host, request_file):
 			if not 'static' in request_file:
 				channel_url = urljoin(host, urlformatted)
 			else:
-				channel_url =createURL(pos,QUAL,STRM,token)
-				# channel_url = template.format('https' if STRM == 'hls' else 'rtmp', SRVR, '443' if STRM == 'hls' else '3625',
-				# 						   SITE, "{:02}".format(pos), QUAL if pos <= QUALLIMIT else '1',
-				# 						   '/playlist.m3u8' if STRM == 'hls' else '', token['hash'])
+				channel_url = createURL(pos, QUAL, STRM, token)
+		# channel_url = template.format('https' if STRM == 'hls' else 'rtmp', SRVR, '443' if STRM == 'hls' else '3625',
+		# 						   SITE, "{:02}".format(pos), QUAL if pos <= QUALLIMIT else '1',
+		# 						   '/playlist.m3u8' if STRM == 'hls' else '', token['hash'])
 		# build playlist entry
 		try:
 			xspfTracks += xspfTrackTemplate.format(escape(program.album), escape(program.quality),
 												   escape(program.language), escape(program.title),
 												   str(program.channel), channel_url,
 												   str(int(chan_map[pos].channum)),
-												   str(int(chan_map[pos].channum) -1 ),
+												   str(int(chan_map[pos].channum) - 1),
 												   escape(program.channelname), escape(program.description))
 			xspfTracks2 += xspfTrack2Template.format(str(int(chan_map[pos].channum) - 1))
 
@@ -2033,7 +2083,7 @@ def build_static_playlist(strmType=None):
 				chan_map[pos].channum, chan_map[pos].channame, SERVER_HOST, SERVER_PATH, chan_map[pos].channum,
 				chan_map[pos].channum,
 				chan_map[pos].channame)
-			new_playlist += '%s\n' % createURL(pos, QUAL, strmType,token)
+			new_playlist += '%s\n' % createURL(pos, QUAL, strmType, token)
 		except:
 			logger.exception("Exception while updating static playlist: ")
 	logger.info("Built static playlist")
@@ -2068,6 +2118,7 @@ def build_test_playlist(hosts):
 	logger.info("Built static playlist")
 	return new_playlist
 
+
 def build_server_playlist():
 	# build playlist using the data we have
 	new_playlist = "#EXTM3U x-tvg-url='%s/epg.xml'\n" % urljoin(SERVER_HOST, SERVER_PATH)
@@ -2078,11 +2129,8 @@ def build_server_playlist():
 		new_playlist += '#EXTINF:-1 tvg-id="1" tvg-name="%s" channel-id="1","%s"\n' % (server[0], server[0])
 		new_playlist += '%s\n' % template.format('https', server[1], '443', SITE, "01", 1, '/mpeg.2ts', token['hash'])
 
-
-
 	logger.info("Built server playlist")
 	return new_playlist
-
 
 
 def thread_playlist():
@@ -2101,7 +2149,7 @@ def thread_playlist():
 
 def create_channel_playlist(sanitized_channel, qual, strm, hash):
 	rtmpTemplate = 'rtmp://{0}.smoothstreams.tv:3625/{1}/ch{2}q{3}.stream?wmsAuthSign={4}'
-	hlsTemplate = 'https://{0}.smoothstreams.tv:443/{1}/ch{2}q{3}.stream/playlist.m3u8?wmsAuthSign={4}=='
+	hlsTemplate = 'https://{0}.smoothstreams.tv:443/{1}/ch{2}q{3}.stream/playlist.m3u8?wmsAuthSign={4}'
 	hls_url = hlsTemplate.format(SRVR, SITE, sanitized_channel, qual, hash)
 	rtmp_url = rtmpTemplate.format(SRVR, SITE, sanitized_channel, qual, hash)
 	file = urllib.request.urlopen(hls_url, timeout=2).read().decode("utf-8")
@@ -2123,6 +2171,7 @@ def create_channel_playlist(sanitized_channel, qual, strm, hash):
 		#    f.write(file)
 		return rtmp_url
 
+
 def create_channel_file(url):
 	strm = 'hls'
 	if url.startswith('rtmp'):
@@ -2134,18 +2183,25 @@ def create_channel_file(url):
 	if strm == 'hls':
 		# Used to support HLS HTTPS urllib.request
 		# https://dnaw1.smoothstreams.tv:443/viewmmasr/ch69q2.stream/playlist.m3u8?wmsAuthSign=c2VydmVyX3RpbWU9OS82LzIwMTggOToxOTowMCBQTSZoYXNoX3ZhbHVlPTZ4R0QzNlhNMW5OTTgzaXBseXpsY2c9PSZ2YWxpZG1pbnV0ZXM9MjQwJmlkPXZpZXdtbWFzci0yNDI2NjY =
-		template = find_between(url,'', 'playlist') + "chunks"  #'https://{0}.smoothstreams.tv:443/{1}/ch{2}q{3}.stream/chunks'
+		template = find_between(url, '', 'playlist') + "chunks"  # 'https://{0}.smoothstreams.tv:443/{1}/ch{2}q{3}.stream/chunks'
 		file = file.replace('chunks', template)
+
+		if CLOUD:
+			# Remove the NimbleSessionId query param that matches the IP for this request with the one that requested the original auth hash.
+			file = re.sub(r'(&)?nimblesessionid=\d+(?(1)|(&)?)', '', file)
+
 		with open(os.path.join(os.path.dirname(sys.argv[0]), 'cache', 'playlist.m3u8'), 'r+') as f:
 			f.write(file)
 		return file
 	else:
 		# not used currently
+		rtmp_url = 'placeholder'
 		template = 'http://{0}.smoothstreams.tv:9100/{1}/ch{2}q{3}.stream/chunks'
 		file = '#EXTM3U\n#EXTINF:' + file[43:110] + "\n" + rtmp_url
 		# with open(os.path.join(os.path.dirname(sys.argv[0]), 'cache', 'playlist.m3u8'), 'r+') as f:
 		#    f.write(file)
 		return rtmp_url
+
 
 def checkChannelURL(url):
 	try:
@@ -2163,23 +2219,27 @@ def checkChannelURL(url):
 		logger.debug("Exception on url %s" % url)
 		return False
 
+
 def fixURL(strm, ch, qual, hash):
 	template = '{0}://{1}.smoothstreams.tv:{2}/{3}/ch{4}q{5}.stream{6}?wmsAuthSign={7}'
-	urlformatted = template.format('https' if strm == 'hls' else 'rtmp', 'SRVR', '443' if strm == 'hls' else '3625', SITE, "{:02}".format(int(ch)), 'QUAL', '/playlist.m3u8' if strm == 'hls' else '', hash)
-	if checkChannelURL(urlformatted.replace('SRVR',SRVR).replace('QUAL',str(1))):
-		return urlformatted.replace('SRVR',SRVR).replace('QUAL',str(1))
+	urlformatted = template.format('https' if strm == 'hls' else 'rtmp', 'SRVR', '443' if strm == 'hls' else '3625',
+								   SITE, "{:02}".format(int(ch)), 'QUAL', '/playlist.m3u8' if strm == 'hls' else '',
+								   hash)
+	if checkChannelURL(urlformatted.replace('SRVR', SRVR).replace('QUAL', str(1))):
+		return urlformatted.replace('SRVR', SRVR).replace('QUAL', str(1))
 	# Check spare
-	if checkChannelURL(urlformatted.replace('SRVR',SRVR_SPARE).replace('QUAL',str(qual))):
-		return urlformatted.replace('SRVR',SRVR_SPARE).replace('QUAL',str(qual))
+	if checkChannelURL(urlformatted.replace('SRVR', SRVR_SPARE).replace('QUAL', str(qual))):
+		return urlformatted.replace('SRVR', SRVR_SPARE).replace('QUAL', str(qual))
 	else:
 		# Check other qualities
-		for q in range(1,4):
+		for q in range(1, 4):
 			if checkChannelURL(urlformatted.replace('SRVR', SRVR).replace('QUAL', str(q))):
 				return urlformatted.replace('SRVR', SRVR).replace('QUAL', str(q))
 			elif checkChannelURL(urlformatted.replace('SRVR', SRVR_SPARE).replace('QUAL', str(q))):
 				return urlformatted.replace('SRVR', SRVR_SPARE).replace('QUAL', str(q))
 		# oh boy we're in trouble now
 		return findChannelURL(input_url=urlformatted, qual=qual)
+
 
 def createURL(chan, qual, strm, token):
 	chan = int(chan)
@@ -2206,17 +2266,18 @@ def createURL(chan, qual, strm, token):
 		sanitizedQuality = qualOptions[quality]
 
 	sanitized_channel = "{:02.0f}".format(int(chan))
-	URLBASE = '{0}://{1}.smoothstreams.tv:{2}/{3}/ch{4}{5}{6}?wmsAuthSign={7}=='
-	url =  URLBASE.format(STREAM_INFO[strm]['domain'],
-	                      SRVR,
-	                      STREAM_INFO[strm]['port'],
-	                      SITE,
-	                      sanitized_channel,
-	                      sanitizedQuality if STREAM_INFO[strm]['quality'] == 'standard' else '.smil',
-	                      STREAM_INFO[strm]['playlist'],
-	                      token['hash'])
+	URLBASE = '{0}://{1}.smoothstreams.tv:{2}/{3}/ch{4}{5}{6}?wmsAuthSign={7}'
+	url = URLBASE.format(STREAM_INFO[strm]['domain'],
+						 SRVR,
+						 STREAM_INFO[strm]['port'],
+						 SITE,
+						 sanitized_channel,
+						 sanitizedQuality if STREAM_INFO[strm]['quality'] == 'standard' else '.smil',
+						 STREAM_INFO[strm]['playlist'],
+						 token['hash'])
 
 	return url
+
 
 ############################################################
 # m3u8 merger
@@ -2256,20 +2317,21 @@ def obtain_m3u8():
 			except:
 				logger.debug("skipped:", inputm3u8[i])
 	return formatted_m3u8
-def obtain_epg():
 
+
+def obtain_epg():
 	if os.path.isfile(os.path.join(os.path.dirname(sys.argv[0]), 'cache', 'combined.xml')):
 		existing = os.path.join(os.path.dirname(sys.argv[0]), 'cache', 'combined.xml')
 		cur_utc_hr = datetime.utcnow().replace(microsecond=0, second=0, minute=0).hour
 		target_utc_hr = (cur_utc_hr // 3) * 3
 		target_utc_datetime = datetime.utcnow().replace(microsecond=0, second=0, minute=0, hour=target_utc_hr)
 		logger.debug("utc time is: %s,    utc target time is: %s,    file time is: %s" % (
-		datetime.utcnow(), target_utc_datetime, datetime.utcfromtimestamp(os.stat(existing).st_mtime)))
+			datetime.utcnow(), target_utc_datetime, datetime.utcfromtimestamp(os.stat(existing).st_mtime)))
 		if os.path.isfile(existing) and os.stat(existing).st_mtime > target_utc_datetime.timestamp():
 			logger.debug("Skipping download of epg")
 			return
-	#clear epg file
-	f = open('./cache/combined.xml','w')
+	# clear epg file
+	f = open('./cache/combined.xml', 'w')
 	f.write('<?xml version="1.0" encoding="UTF-8"?>'.rstrip('\r\n'))
 	f.write('''<tv></tv>''')
 	f.close()
@@ -2319,6 +2381,7 @@ def xmltv_merger(xml_url):
 		f.seek(0, 0)
 		f.write('<?xml version="1.0" encoding="UTF-8"?>'.rstrip('\r\n') + content)
 	return
+
 
 ############################################################
 # TVHeadend
@@ -2457,7 +2520,7 @@ def tvh_lineup():
 	for c in get_tvh_channels():
 		if c['enabled']:
 			url = 'http://%s:%s@%s:9981/stream/channel/%s?profile=%s&weight=%s' % (
-			TVHUSER, TVHPASS, TVHURL, c['uuid'], tvhstreamProfile, int(tvhWeight))
+				TVHUSER, TVHPASS, TVHURL, c['uuid'], tvhstreamProfile, int(tvhWeight))
 			lineup.append({'GuideNumber': str(c['number']),
 						   'GuideName': c['name'],
 						   'URL': url
@@ -2500,6 +2563,7 @@ def tvh_device():
 	}
 	return render_template('device.xml', data=tvhdiscoverData), {'Content-Type': 'application/xml'}
 
+
 def ffmpegPipe(url):
 	logger.debug("starting generate function")
 	cmdline = list()
@@ -2526,6 +2590,7 @@ def ffmpegPipe(url):
 
 	finally:
 		proc.kill()
+
 
 ############################################################
 # Kodi
@@ -2557,7 +2622,8 @@ def build_kodi_playlist():
 				chan_map[pos].channum, chan_map[pos].channame, SERVER_HOST, SERVER_PATH, chan_map[pos].channum,
 				chan_map[pos].channum,
 				chan_map[pos].channame)
-			new_playlist += '%s\n' % createURL(pos,QUAL,'rtmp',token) #rtmpTemplate.format(SRVR, SITE, "{:02}".format(pos), QUAL if pos <= QUALLIMIT else '1',token['hash'])
+			new_playlist += '%s\n' % createURL(pos, QUAL, 'rtmp',
+											   token)  # rtmpTemplate.format(SRVR, SITE, "{:02}".format(pos), QUAL if pos <= QUALLIMIT else '1',token['hash'])
 			prog = getProgram(pos)
 			if prog.title != 'none':
 				new_playlist += '#EXTINF:-1 tvg-id="%s" tvg-name="%s" tvg-logo="%s/%s/%s.png" channel-id="%s" group-title="LIVE",%s\n' % (
@@ -2626,6 +2692,7 @@ style = """
 
 
 def create_menu():
+	menu_host = EXT_HOST if (CLOUD and request.environ.get('REMOTE_ADDR') != LISTEN_IP) else SERVER_HOST
 	footer = '<p>Donations: PayPal to vorghahn.sstv@gmail.com  or BTC - 19qvdk7JYgFruie73jE4VvW7ZJBv8uGtFb</p>'
 	with open("./cache/settings.html", "w") as html:
 		html.write("""<html>
@@ -2638,9 +2705,19 @@ def create_menu():
 		html.write('<section class="container"><div class="left-half">')
 		html.write("<h1>YAP Settings</h1>")
 		template = "<a href='{1}/{2}/{0}.html'>{3}</a>"
-		html.write("<p>" + template.format("settings",SERVER_HOST, SERVER_PATH,"Options") + " " + template.format("howto",SERVER_HOST, SERVER_PATH,"Instructions") + " " + template.format("channels",SERVER_HOST, SERVER_PATH,"Channels List") + " " + template.format("adv_settings",SERVER_HOST, SERVER_PATH,"Advanced Settings") + "</p>")
+		html.write(
+			"<p>" + template.format("settings", menu_host, SERVER_PATH, "Options") + " " + template.format("howto",
+																											 menu_host,
+																											 SERVER_PATH,
+																											 "Instructions") + " " + template.format(
+				"channels", menu_host, SERVER_PATH, "Channels List") + " " + template.format("adv_settings",
+																							   menu_host, SERVER_PATH,
+																							   "Advanced Settings") + " " + template.format(
+				"paths",
+				menu_host, SERVER_PATH,
+				"Proxy Paths") + "</p>")
 
-		html.write('<form action="%s/%s/handle_data" method="post">' % (SERVER_HOST, SERVER_PATH))
+		html.write('<form action="%s/%s/handle_data" method="post">' % (menu_host, SERVER_PATH))
 
 		channelmap = {}
 		chanindex = 0
@@ -2652,13 +2729,13 @@ def create_menu():
 				html.write('<tr><td>Service:</td><td><select name="Service" size="1">')
 				for option in providerList:
 					html.write('<option value="%s"%s>%s</option>' % (
-					option[0], ' selected' if SITE == option[1] else "", option[0]))
+						option[0], ' selected' if SITE == option[1] else "", option[0]))
 				html.write('</select></td></tr>')
 			elif setting.lower() == 'server':
 				html.write('<tr><td>Server:</td><td><select name="Server" size="1">')
 				for option in serverList:
 					html.write('<option value="%s"%s>%s</option>' % (
-					option[0], ' selected' if SRVR == option[1] else "", option[0]))
+						option[0], ' selected' if SRVR == option[1] else "", option[0]))
 				html.write('</select></td></tr>')
 			elif setting.lower() == 'stream':
 				html.write('<tr><td>Stream:</td><td><select name="Stream" size="1">')
@@ -2670,11 +2747,11 @@ def create_menu():
 				html.write('<tr><td>Quality:</td><td><select name="Quality" size="1">')
 				for option in qualityList:
 					html.write('<option value="%s"%s>%s</option>' % (
-					option[0], ' selected' if QUAL == option[1] else "", option[0]))
+						option[0], ' selected' if QUAL == option[1] else "", option[0]))
 				html.write('</select></td></tr>')
 			elif setting.lower() == 'password':
 				html.write('<tr><td>%s:</td><td><input name="%s" type="Password" value="%s"></td></tr>' % (
-				setting, setting, PASS))
+					setting, setting, PASS))
 			else:
 				val = "Unknown"
 				if setting == "Username":
@@ -2694,15 +2771,15 @@ def create_menu():
 		html.write('</form>')
 		html.write("<p>You are running version (%s %s), the latest is %s</p>" % (type, __version__, latest_ver))
 		html.write("</br><p>Restarts can take a while, it is not immediate.</p>")
-		html.write('<form action="%s/%s/handle_data" method="post">' % (SERVER_HOST, SERVER_PATH))
+		html.write('<form action="%s/%s/handle_data" method="post">' % (menu_host, SERVER_PATH))
 		html.write('<input type="hidden" name="restart"  value="1">')
 		html.write('<input type="submit"  value="Restart">')
 		html.write('</form>')
-		html.write('<form action="%s/%s/handle_data" method="post">' % (SERVER_HOST, SERVER_PATH))
+		html.write('<form action="%s/%s/handle_data" method="post">' % (menu_host, SERVER_PATH))
 		html.write('<input type="hidden" name="restart"  value="2">')
 		html.write('<input type="submit"  value="Update + Restart">')
 		html.write('</form>')
-		html.write('<form action="%s/%s/handle_data" method="post">' % (SERVER_HOST, SERVER_PATH))
+		html.write('<form action="%s/%s/handle_data" method="post">' % (menu_host, SERVER_PATH))
 		html.write('<input type="hidden" name="restart"  value="3">')
 		devname = latestfile.replace('master', 'dev')
 		html.write('<input type="submit"  value="Update(Dev Branch) + Restart">')
@@ -2718,21 +2795,23 @@ def create_menu():
 		html.write('</div><div class="right-half"><h1>YAP Outputs</h1>')
 
 		html.write("<table><tr><td rowspan='2'>Standard Outputs</td><td>m3u8 - %s/playlist.m3u8</td></tr>" % urljoin(
-			SERVER_HOST, SERVER_PATH))
-		html.write("<tr><td>EPG - %s/epg.xml</td></tr>" % urljoin(SERVER_HOST, SERVER_PATH))
+			menu_host, SERVER_PATH))
+		html.write("<tr><td>EPG - %s/epg.xml</td></tr>" % urljoin(menu_host, SERVER_PATH))
 		html.write("<tr><td>&nbsp;</td><td>&nbsp;</td></tr>")
 		html.write(
-			"<tr><td>Sports EPG (Alternative)</td><td>%s/sports.xml</td></tr>" % urljoin(SERVER_HOST, SERVER_PATH))
+			"<tr><td>Sports Playlist</td><td>%s/sports.m3u8</td></tr>" % urljoin(menu_host, SERVER_PATH))
+		html.write(
+			"<tr><td>Sports EPG (Alternative)</td><td>%s/sports.xml</td></tr>" % urljoin(menu_host, SERVER_PATH))
 		html.write("<tr><td>&nbsp;</td><td>&nbsp;</td></tr>")
 		html.write(
-			"<tr><td>Kodi RTMP supported</td><td>m3u8 - %s/kodi.m3u8</td></tr>" % urljoin(SERVER_HOST, SERVER_PATH))
+			"<tr><td>Kodi RTMP supported</td><td>m3u8 - %s/kodi.m3u8</td></tr>" % urljoin(menu_host, SERVER_PATH))
 		html.write("<tr><td>&nbsp;</td><td>&nbsp;</td></tr>")
 
-		html.write("<tr><td rowspan='2'>Plex Live<sup>1</sup></td><td>Tuner - %s</td></tr>" % urljoin(SERVER_HOST,
+		html.write("<tr><td rowspan='2'>Plex Live<sup>1</sup></td><td>Tuner - %s</td></tr>" % urljoin(menu_host,
 																									  SERVER_PATH))
-		html.write("<tr><td>EPG - %s/epg.xml</td></tr>" % urljoin(SERVER_HOST, SERVER_PATH))
+		html.write("<tr><td>EPG - %s/epg.xml</td></tr>" % urljoin(menu_host, SERVER_PATH))
 		html.write("<tr><td>&nbsp;</td><td>&nbsp;</td></tr>")
-		html.write("<tr><td>TVHeadend<sup>1</sup></td><td>%s/tvh.m3u8</td></tr>" % urljoin(SERVER_HOST, SERVER_PATH))
+		html.write("<tr><td>TVHeadend<sup>1</sup></td><td>%s/tvh.m3u8</td></tr>" % urljoin(menu_host, SERVER_PATH))
 		html.write("<tr><td>&nbsp;</td><td>&nbsp;</td></tr>")
 		html.write(
 			"<tr><td rowspan='2'>Remote Internet access<sup>2</sup></td><td>m3u8 - %s/external.m3u8</td></tr>" % urljoin(
@@ -2742,31 +2821,32 @@ def create_menu():
 
 		html.write(
 			"<tr><td rowspan='2'>Combined Outputs<sup>2</sup></td><td>m3u8 - %s/combined.m3u8</td></tr>" % urljoin(
-				SERVER_HOST, SERVER_PATH))
-		html.write("<tr><td>epg - %s/combined.xml</td></tr>" % urljoin(SERVER_HOST, SERVER_PATH))
+				menu_host, SERVER_PATH))
+		html.write("<tr><td>epg - %s/combined.xml</td></tr>" % urljoin(menu_host, SERVER_PATH))
 		html.write("<tr><td>&nbsp;</td><td>&nbsp;</td></tr>")
 
 		html.write(
-			"<tr><td>Static Playlist</td><td>m3u8 - %s/static.m3u8</td></tr>" % urljoin(SERVER_HOST, SERVER_PATH))
+			"<tr><td>Static Playlist</td><td>m3u8 - %s/static.m3u8</td></tr>" % urljoin(menu_host, SERVER_PATH))
 		html.write("<tr><td>&nbsp;</td><td>&nbsp;</td></tr>")
 
 		html.write(
-			"<tr><td rowspan='2'>TVHProxy<sup>3</sup></td><td>Tuner - %s</td></tr>" % urljoin(SERVER_HOST, 'tvh'))
+			"<tr><td rowspan='2'>TVHProxy<sup>3</sup></td><td>Tuner - %s</td></tr>" % urljoin(menu_host, 'tvh'))
 		html.write("<tr><td>EPG - http://%s:9981/xmltv/channels</td></tr>" % TVHURL)
 		html.write("<tr><td>&nbsp;</td><td>&nbsp;</td></tr>")
-		html.write("<tr><td>Test Playlist for troubleshooting</td><td>%s/test.m3u8</td></tr>" % urljoin(SERVER_HOST,
+		html.write("<tr><td>Test Playlist for troubleshooting</td><td>%s/test.m3u8</td></tr>" % urljoin(menu_host,
 																										SERVER_PATH))
 		html.write("<tr><td>&nbsp;</td><td>&nbsp;</td></tr>")
-		html.write("<tr><td>Dynamic xspf, includes currently showing programs</td><td>%s/playlist.xspf</td></tr>" % urljoin(SERVER_HOST,
-																										SERVER_PATH))
-		html.write("<tr><td>Static xspf</td><td>%s/static.xspf</td></tr>" % urljoin(SERVER_HOST,
-																										SERVER_PATH))
+		html.write(
+			"<tr><td>Dynamic xspf, includes currently showing programs</td><td>%s/playlist.xspf</td></tr>" % urljoin(
+				menu_host,
+				SERVER_PATH))
+		html.write("<tr><td>Static xspf</td><td>%s/static.xspf</td></tr>" % urljoin(menu_host,
+																					SERVER_PATH))
 		html.write("<tr><td>&nbsp;</td><td>&nbsp;</td></tr>")
 		html.write("<tr><td>Note 1:</td><td>Requires FFMPEG installation and setup</td></tr>")
 		html.write("<tr><td>Note 2:</td><td>Requires External IP and port in advancedsettings</td></tr>")
 		html.write("<tr><td>Note 3:</td><td>Requires TVH proxy setup in advancedsettings</td></tr></table>")
 		html.write("</div></section></body></html>\n")
-
 
 	with open("./cache/adv_settings.html", "w") as html:
 		html.write("""<html>
@@ -2779,23 +2859,39 @@ def create_menu():
 		html.write('<section class="container"><div class="left-half">')
 		html.write("<h1>YAP Settings</h1>")
 		template = "<a href='{1}/{2}/{0}.html'>{3}</a>"
-		html.write("<p>" + template.format("settings",SERVER_HOST, SERVER_PATH,"Options") + " " + template.format("howto",SERVER_HOST, SERVER_PATH,"Instructions") + " " + template.format("channels",SERVER_HOST, SERVER_PATH,"Channels List") + " " + template.format("adv_settings",SERVER_HOST, SERVER_PATH,"Advanced Settings") + "</p>")
+		html.write(
+			"<p>" + template.format("settings", menu_host, SERVER_PATH, "Options") + " " + template.format("howto",
+																											 menu_host,
+																											 SERVER_PATH,
+																											 "Instructions") + " " + template.format(
+				"channels", menu_host, SERVER_PATH, "Channels List") + " " + template.format("adv_settings",
+																							   menu_host, SERVER_PATH,
+																							   "Advanced Settings") + " " + template.format(
+				"paths",
+				menu_host, SERVER_PATH,
+				"Proxy Paths") + "</p>")
 
-		html.write('<form action="%s/%s/handle_data" method="post">' % (SERVER_HOST, SERVER_PATH))
+		html.write('<form action="%s/%s/handle_data" method="post">' % (menu_host, SERVER_PATH))
 
 		channelmap = {}
 		chanindex = 0
 		adv_set = ["kodiuser", "kodipass", "ffmpegloc", "kodiport", "extram3u8url", "extram3u8name", "extram3u8file",
-		           "extraxmlurl", "tvhredirect", "tvhaddress", "tvhuser", "tvhpass", "overridexml", "checkchannel", "pipe"]
+				   "extraxmlurl", "tvhredirect", "tvhaddress", "tvhuser", "tvhpass", "overridexml", "checkchannel",
+				   "pipe"]
 		html.write('<table width="300" border="2">')
 		for setting in adv_set:
 			if setting.lower() == 'kodipass':
 				html.write('<tr><td>%s:</td><td><input name="%s" type="Password" value="%s"></td></tr>' % (
-				setting, setting, KODIPASS))
+					setting, setting, KODIPASS))
 			elif setting == "checkchannel":
-				html.write('<tr><td>%s:</td><td><select name="%s"  size="1"><option value="True" %s>Enabled</option><option value="False" %s>Disabled</option></select></td></tr>' % (setting, setting,  ' selected' if CHECK_CHANNEL == True else "", ' selected' if CHECK_CHANNEL == False else ""))
+				html.write(
+					'<tr><td>%s:</td><td><select name="%s"  size="1"><option value="True" %s>Enabled</option><option value="False" %s>Disabled</option></select></td></tr>' % (
+						setting, setting, ' selected' if CHECK_CHANNEL == True else "",
+						' selected' if CHECK_CHANNEL == False else ""))
 			elif setting == "pipe":
-				html.write('<tr><td>%s:</td><td><select name="%s"  size="1"><option value="True" %s>Enabled</option><option value="False" %s>Disabled</option></select></td></tr>' % (setting, setting,  ' selected' if PIPE == True else "", ' selected' if PIPE == False else ""))
+				html.write(
+					'<tr><td>%s:</td><td><select name="%s"  size="1"><option value="True" %s>Enabled</option><option value="False" %s>Disabled</option></select></td></tr>' % (
+						setting, setting, ' selected' if PIPE == True else "", ' selected' if PIPE == False else ""))
 
 			else:
 				val = "Unknown"
@@ -2825,21 +2921,22 @@ def create_menu():
 					val = OVRXML
 
 				if not (setting == "ffmpegloc" and not platform.system() == 'Windows'):
-					html.write('<tr><td>%s:</td><td><input name="%s" type="text" value="%s"></td></tr>' % (setting, setting, val))
+					html.write('<tr><td>%s:</td><td><input name="%s" type="text" value="%s"></td></tr>' % (
+						setting, setting, val))
 		html.write('</table>')
 		html.write('<input type="submit"  value="Submit">')
 		html.write('</form>')
 		html.write("<p>You are running version (%s %s), the latest is %s</p>" % (type, __version__, latest_ver))
 		html.write("</br><p>Restarts can take a while, it is not immediate.</p>")
-		html.write('<form action="%s/%s/handle_data" method="post">' % (SERVER_HOST, SERVER_PATH))
+		html.write('<form action="%s/%s/handle_data" method="post">' % (menu_host, SERVER_PATH))
 		html.write('<input type="hidden" name="restart"  value="1">')
 		html.write('<input type="submit"  value="Restart">')
 		html.write('</form>')
-		html.write('<form action="%s/%s/handle_data" method="post">' % (SERVER_HOST, SERVER_PATH))
+		html.write('<form action="%s/%s/handle_data" method="post">' % (menu_host, SERVER_PATH))
 		html.write('<input type="hidden" name="restart"  value="2">')
 		html.write('<input type="submit"  value="Update + Restart">')
 		html.write('</form>')
-		html.write('<form action="%s/%s/handle_data" method="post">' % (SERVER_HOST, SERVER_PATH))
+		html.write('<form action="%s/%s/handle_data" method="post">' % (menu_host, SERVER_PATH))
 		html.write('<input type="hidden" name="restart"  value="3">')
 		html.write('<input type="submit"  value="Update(Dev Branch) + Restart">')
 		html.write('</form>')
@@ -2850,20 +2947,30 @@ def create_menu():
 		html.write(footer)
 		html.write("</div></section></body></html>\n")
 
-
 	with open("./cache/channels.html", "w") as html:
 		global chan_map
 		html.write("""<html><head><title>YAP</title><meta charset="UTF-8">%s</head><body>\n""" % (style,))
 		html.write("<h1>Channel List and Upcoming Shows</h1>")
 		template = "<a href='{1}/{2}/{0}.html'>{3}</a>"
-		html.write("<p>" + template.format("settings",SERVER_HOST, SERVER_PATH,"Options") + " " + template.format("howto",SERVER_HOST, SERVER_PATH,"Instructions") + " " + template.format("channels",SERVER_HOST, SERVER_PATH,"Channels List") + " " + template.format("adv_settings",SERVER_HOST, SERVER_PATH,"Advanced Settings") + "</p>")
+		html.write(
+			"<p>" + template.format("settings", menu_host, SERVER_PATH, "Options") + " " + template.format("howto",
+																											 menu_host,
+																											 SERVER_PATH,
+																											 "Instructions") + " " + template.format(
+				"channels", menu_host, SERVER_PATH, "Channels List") + " " + template.format("adv_settings",
+																							   menu_host, SERVER_PATH,
+																							   "Advanced Settings") + " " + template.format(
+				"paths",
+				menu_host, SERVER_PATH,
+				"Proxy Paths") + "</p>")
+		html.write("<a href='https://guide.smoothstreams.tv/'>Click here to go to the SmoothStreams Official Guide</a>")
 		html.write('<section class="container"><div class="left-half"><table width="300" border="1">')
 		template = "<td>{0}</td><td><a href='{2}/{3}/playlist.m3u8?ch={0}'><img src='{2}/{3}/{0}.png'></a></td></td>"
 		for i in chan_map:
-			if i%5 == 1:
+			if i % 5 == 1:
 				html.write("<tr>")
-			html.write(template.format(chan_map[i].channum, chan_map[i].channame, SERVER_HOST, SERVER_PATH))
-			if i%5 == 0:
+			html.write(template.format(chan_map[i].channum, chan_map[i].channame, menu_host, SERVER_PATH))
+			if i % 5 == 0:
 				html.write("</tr>")
 		html.write("</table>")
 		html.write("</br>%s</div>" % footer)
@@ -2873,7 +2980,8 @@ def create_menu():
 			prog = getProgram(i)
 			if prog.title != 'none':
 				try:
-					html.write(template.format(chan_map[i].channum, str(prog.title).encode('utf-8'), SERVER_HOST, SERVER_PATH))
+					html.write(
+						template.format(chan_map[i].channum, str(prog.title).encode('utf-8'), menu_host, SERVER_PATH))
 				except:
 					logger.exception(prog.title)
 		html.write("</div></section>")
@@ -2883,10 +2991,11 @@ def create_menu():
 		html.write("""<html><head><title>YAP</title><meta charset="UTF-8">%s</head><body>\n""" % (style,))
 		template = "<h2><a href='{1}/{2}/{0}.html'>{3}</a></h2>"
 		html.write("<h1>Welcome to YAP!</h1>")
-		html.write(template.format("settings",SERVER_HOST, SERVER_PATH,"Options"))
-		html.write(template.format("howto",SERVER_HOST, SERVER_PATH,"Instructions"))
-		html.write(template.format("channels",SERVER_HOST, SERVER_PATH,"Channels List"))
-		html.write(template.format("adv_settings", SERVER_HOST, SERVER_PATH, "Advanced Settings"))
+		html.write(template.format("settings", menu_host, SERVER_PATH, "Options"))
+		html.write(template.format("howto", menu_host, SERVER_PATH, "Instructions"))
+		html.write(template.format("channels", menu_host, SERVER_PATH, "Channels List"))
+		html.write(template.format("adv_settings", menu_host, SERVER_PATH, "Advanced Settings"))
+		html.write(template.format("paths", menu_host, SERVER_PATH, "Proxy Paths"))
 		html.write(footer)
 		html.write("</body></html>\n")
 
@@ -2894,18 +3003,28 @@ def create_menu():
 		html.write("""<html><head><title>YAP</title><meta charset="UTF-8">%s</head><body>\n""" % (style,))
 		template = "<a href='{1}/{2}/{0}.html'>{3}</a>"
 		html.write("<h1>Welcome to YAP!</h1>")
-		html.write("<p>" + template.format("settings",SERVER_HOST, SERVER_PATH,"Options") + " " + template.format("howto",SERVER_HOST, SERVER_PATH,"Instructions") + " " + template.format("channels",SERVER_HOST, SERVER_PATH,"Channels List") + " " + template.format("adv_settings",SERVER_HOST, SERVER_PATH,"Advanced Settings") + "</p>")
+		html.write(
+			"<p>" + template.format("settings", menu_host, SERVER_PATH, "Options") + " " + template.format("howto",
+																											 menu_host,
+																											 SERVER_PATH,
+																											 "Instructions") + " " + template.format(
+				"channels", menu_host, SERVER_PATH, "Channels List") + " " + template.format("adv_settings",
+																							   menu_host, SERVER_PATH,
+																							   "Advanced Settings") + "</p>")
 		html.write("<h2>Work in progress.</h2>")
 
 		html.write("""<h2>Commandline Arguments</h2></br><p>'install' - forces recreation of the install function which creates certain files, such as the tvh internal grabber</br></br>
 'headless' - uses command line for initial setup rather than gui</br></br>
+'cloud' - forces cloud hosting mode, which exposes the settings web interface on the external ip and port configured, as well as modifying the generated links for such usage</br></br>
 'tvh' - each call to a piped channel will return channel 01 which is a 24/7 channel so will always generate a positive result, this allows TVH to create all services</p></br>""")
 
-		html.write("<h2><a href='https://seo-michael.co.uk/how-to-setup-livetv-pvr-simple-xbmc-kodi/'>Kodi Setup</a></h2>")
+		html.write(
+			"<h2><a href='https://seo-michael.co.uk/how-to-setup-livetv-pvr-simple-xbmc-kodi/'>Kodi Setup</a></h2>")
 		html.write("<p>Use this information to populate the settings:</p>")
-		html.write("<p>m3u8 - %s/kodi.m3u8</p>" % urljoin(SERVER_HOST, SERVER_PATH))
-		html.write("<p>EPG - %s/epg.xml</p>" % urljoin(SERVER_HOST, SERVER_PATH))
-		html.write('''<p>RTMP is an issue so there's a special playlist for it (kodi.m3u8), it has two of every channel in both rtmp and hls, in kodi Tv use the Left hand menu  and select group or filter. Then select dynamic (forced hls) or static rtmp.For static_refresh channel (151) don't use it on the guide page, use it on the channel list page. Otherwise kodi will crash. This will lock kodi for about 20secs but refresh the playlist.</p>''')
+		html.write("<p>m3u8 - %s/kodi.m3u8</p>" % urljoin(menu_host, SERVER_PATH))
+		html.write("<p>EPG - %s/epg.xml</p>" % urljoin(menu_host, SERVER_PATH))
+		html.write(
+			'''<p>RTMP is an issue so there's a special playlist for it (kodi.m3u8), it has two of every channel in both rtmp and hls, in kodi Tv use the Left hand menu  and select group or filter. Then select dynamic (forced hls) or static rtmp.For static_refresh channel (151) don't use it on the guide page, use it on the channel list page. Otherwise kodi will crash. This will lock kodi for about 20secs but refresh the playlist.</p>''')
 
 		html.write("<h2>Ensure you can get YAP working in Kodi or VLC first before attmepting Plex or TVHeadend!</h2>")
 		html.write("<h2><a href='https://imgur.com/a/OZkN0'>Plex Setup</a></h2>")
@@ -3001,6 +3120,57 @@ A url source for the epg "overridexml":"url/string"</p>""")
 
 		html.write("</body></html>\n")
 
+	with open("./cache/paths.html", "w") as html:
+		html.write("""<html><head><title>YAP</title><meta charset="UTF-8">%s</head><body>\n""" % (style,))
+		template = "<a href='{1}/{2}/{0}.html'>{3}</a>"
+		html.write("<h1>Welcome to YAP!</h1>")
+		html.write(
+			"<p>" + template.format("settings", menu_host, SERVER_PATH, "Options") + " " + template.format("howto",
+																											 menu_host,
+																											 SERVER_PATH,
+																											 "Instructions") + " " + template.format(
+				"channels", menu_host, SERVER_PATH, "Channels List") + " " + template.format("adv_settings",
+																							   menu_host, SERVER_PATH,
+																							   "Advanced Settings") + " " + template.format(
+				"paths",
+				menu_host, SERVER_PATH,
+				"Proxy Paths") + "</p>")
+		html.write("<h2>Work in progress.</h2>")
+
+		html.write("<h2>Proxy URL Paths</h2>")
+		html.write("""<p>m3u8 playlists can be called using http://ip:port/sstv/playlist.m3u8 optional arguments include 'strm' to overide defaults</p>
+<p>alternatively using http://ip:port/sstv/{strm}.m3u8 strm options are 'hls', 'hlsa', 'rtmp', 'mpegts', 'rtsp', 'dash', 'wss'</p>
+<p>a specific mpeg playlsit can also be accesed via http://ip:port/sstv/mpeg.2ts</p>
+<p>single channels can be called using http://ip:port/sstv/playlist.m3u8?ch=# or http://ip:port/sstv/ch# optional arguments 'strm','qual' to overide defaults</p>
+<p>kodi m3u8 url is http://ip:port/sstv/kodi.m3u8</p>
+<p>sports m3u8 url is http://ip:port/sstv/sports.m3u8</p>
+<p>EPG url is http://ip:port/sstv/epg.xml</p>
+<p>Sports EPG url is http://ip:port/sstv/sports.xml</p>
+<p>Plex Live TV url is http://ip:port/sstv</p>
+<p>TVHeadend Proxy can be used using http://ip:port/sstv/tvh.m3u8</p>
+<p>External m3u8 url is http://externalip:externalport/sstv/external.m3u8</p>
+<p>Combined m3u8 url is http://ip:port/sstv/combined.m3u8</p>
+<p>Combined EPG url is http://ip:port/sstv/combined.xml</p>
+<p>Static m3u8 url is http://ip:port/sstv/static.m3u8 optional arguments include 'strm' to overide defaults</p>
+<p>TVH's own EPG url is http://127.0.0.1:9981/xmltv/channels</p>
+<p>Static XSPF url is http://ip:port/sstv/static.xspf</p>
+<p>Dynamic XSPF url is http://ip:port/sstv/playlist.xspf</p>
+		<p></p>
+		<p></p>
+		<p></p>
+		<p></p>
+		<p></p>
+		<p></p>
+		<p></p>
+		<p></p>
+		<p></p>		
+		""")
+
+		html.write(footer)
+
+		html.write("</body></html>\n")
+
+
 def close_menu(restart):
 	with open("./cache/close.html", "w") as html:
 		html.write("""<html><head><title>YAP</title><meta charset="UTF-8">%s</head><body>\n""" % (style,))
@@ -3023,12 +3193,9 @@ def close_menu(restart):
 		html.write("</body></html>\n")
 
 
-
-
 def restart_program():
 	os.system('cls' if os.name == 'nt' else 'clear')
 	args = sys.argv[:]
-	print(args)
 
 	logger.info("YAP is restarting...")
 	FULL_PATH = sys.argv[0]
@@ -3123,7 +3290,9 @@ def handle_data():
 	else:
 		close_menu(False)
 	return redirect(request_page, code=302)
-	# return send_from_directory(os.path.join(os.path.dirname(sys.argv[0]), 'cache'), 'close.html')
+
+
+# return send_from_directory(os.path.join(os.path.dirname(sys.argv[0]), 'cache'), 'close.html')
 
 
 @app.route('/')
@@ -3158,15 +3327,15 @@ def bridge(request_file):
 	check_token()
 	try:
 		client = find_client(request.headers['User-Agent'])
-		logger.debug("Client is %s, user agent is %s" %(client, request.headers['User-Agent']))
+		logger.debug("Client is %s, user agent is %s" % (client, request.headers['User-Agent']))
 	except:
 		logger.debug("No user-agent provided by %s", request.environ.get('REMOTE_ADDR'))
 		client = 'unk'
 
 	if request_file.lower() == ('version'):
-		resp = {'version':__version__, 'type':type}
+		resp = {'version': __version__, 'type': type}
 		return jsonify(resp)
-	
+
 	if request_file.lower().endswith('.xspf'):
 		playlist = build_xspf(SERVER_HOST, request_file)
 		logger.info("XSPF playlist was requested by %s", request.environ.get('REMOTE_ADDR'))
@@ -3247,6 +3416,12 @@ def bridge(request_file):
 		create_menu()
 		return send_from_directory(os.path.join(os.path.dirname(sys.argv[0]), 'cache'), 'channels.html')
 
+	# return paths menu
+	elif request_file.lower().startswith('paths'):
+		logger.info("Channels was requested by %s", request.environ.get('REMOTE_ADDR'))
+		create_menu()
+		return send_from_directory(os.path.join(os.path.dirname(sys.argv[0]), 'cache'), 'paths.html')
+
 	# return howto menu
 	elif request_file.lower().startswith('howto'):
 		logger.info("Howto was requested by %s", request.environ.get('REMOTE_ADDR'))
@@ -3308,7 +3483,14 @@ def bridge(request_file):
 		logger.info("TVH channels playlist was requested by %s", request.environ.get('REMOTE_ADDR'))
 		return Response(tvhplaylist, mimetype='application/x-mpegURL')
 
-	elif request_file.lower() == 'playlist.m3u8' or request_file.lower().startswith('ch') or request_file.lower() == 'mpeg.2ts' :
+	# returns sports playlist
+	elif request_file.lower() == ('sports.m3u8'):
+		sportsplaylist = build_sports_playlist(SERVER_HOST)
+		logger.info("Sports channels playlist was requested by %s", request.environ.get('REMOTE_ADDR'))
+		return Response(sportsplaylist, mimetype='application/x-mpegURL')
+
+	elif request_file.lower() == 'playlist.m3u8' or request_file.lower().startswith(
+			'ch') or request_file.lower() == 'mpeg.2ts':
 		# returning Dynamic channels
 		if request.args.get('ch') or request_file.lower().startswith('ch'):
 			if request_file.lower().startswith('ch'):
@@ -3332,18 +3514,17 @@ def bridge(request_file):
 				strm = 'ts' if STRM == 'mpegts' else 'm3u8'
 				if request.args.get('strm'):
 					strm = request.args.get('strm')
-				tokens = urllib.parse.urlencode({"token":str(tokens)[1:]})
+				tokens = urllib.parse.urlencode({"token": str(tokens)[1:]})
 
 				if int(chan) > 150:
 					channel = chan
 				else:
 					channel = vaders_channels[chan]
 				channel_url = vaders_url.format(channel, strm) + tokens
-				print(channel_url)
 				return redirect(channel_url, code=302)
 
 			qual = 1
-			if request.args.get('qual'):# and int(sanitized_channel) <= QUALLIMIT:
+			if request.args.get('qual'):  # and int(sanitized_channel) <= QUALLIMIT:
 				qual = request.args.get('qual')
 			elif int(sanitized_channel) <= QUALLIMIT:
 				qual = QUAL
@@ -3355,7 +3536,7 @@ def bridge(request_file):
 			output_url = createURL(sanitized_channel, qual, strm, token)
 
 			# if strm == 'mpegts':
-				# return auto(sanitized_channel, qual)
+			# return auto(sanitized_channel, qual)
 
 			# channel fixing for dead server/Quality
 			if CHECK_CHANNEL and strm == 'hls' and not checkChannelURL(output_url):
@@ -3363,7 +3544,6 @@ def bridge(request_file):
 			# creates the output playlist files and returns it as a variable as well
 			if strm == 'hls':
 				output_file = create_channel_file(output_url)
-
 
 			# useful for debugging
 			logger.debug("URL returned: %s" % output_url)
@@ -3383,7 +3563,7 @@ def bridge(request_file):
 				return response
 
 			elif returntype == 1 or client == 'kodi':
-				# hlsTemplate = 'https://{0}.smoothstreams.tv:443/{1}/ch{2}q{3}.stream/playlist.m3u8?wmsAuthSign={4}=='
+				# hlsTemplate = 'https://{0}.smoothstreams.tv:443/{1}/ch{2}q{3}.stream/playlist.m3u8?wmsAuthSign={4}'
 				# ss_url = hlsTemplate.format(SRVR, SITE, sanitized_channel, qual, token['hash'])
 				# some players are having issues with http/https redirects
 				logger.debug("returning hls url redirect")
@@ -3414,11 +3594,12 @@ def bridge(request_file):
 			else:
 				strmType = STRM
 			playlist = build_playlist(SERVER_HOST, strmType)
-			logger.info("All channels playlist(%s) was requested by %s" % (strmType, request.environ.get('REMOTE_ADDR')))
+			logger.info(
+				"All channels playlist(%s) was requested by %s" % (strmType, request.environ.get('REMOTE_ADDR')))
 			return Response(playlist, mimetype='application/x-mpegURL')
 
 	elif '.m3u8' in request_file.lower():
-		strng = request_file.lower().replace('.m3u8','')
+		strng = request_file.lower().replace('.m3u8', '')
 		if strng in streamtype:
 			strmType = strng
 		else:
@@ -3500,7 +3681,8 @@ def auto(request_file, qual=""):
 		url = createURL(sanitized_channel, sanitized_qual, 'mpegts', token)
 
 		logger.debug(
-			"sanitized_channel: %s sanitized_qual: %s QUAL: %s qual: %s" % (sanitized_channel, sanitized_qual, QUAL, qual))
+			"sanitized_channel: %s sanitized_qual: %s QUAL: %s qual: %s" % (
+				sanitized_channel, sanitized_qual, QUAL, qual))
 
 		# changing to mpegts
 		# if CHECK_CHANNEL and not checkChannelURL(url):
@@ -3513,7 +3695,6 @@ def auto(request_file, qual=""):
 		# 	a = 1
 		# except timeout:
 		# 	#special arg for tricking tvh into saving every channel first time
-		# 	print("timeout")
 		# 	sanitized_channel = '01'
 		# 	sanitized_qual = '3'
 		# 	url = template.format(SRVR, SITE, sanitized_channel,sanitized_qual, token['hash'])
@@ -3533,11 +3714,12 @@ def auto(request_file, qual=""):
 			url = createURL(sanitized_channel, sanitized_qual, 'hls', token)
 			logger.debug("Piping")
 			return Response(response=ffmpegPipe(url), status=200, mimetype='video/mp2t',
-			                headers={'Access-Control-Allow-Origin': '*', "Content-Type": "video/mp2t",
-			                         "Content-Disposition": "inline", "Content-Transfer-Enconding": "binary"})
+							headers={'Access-Control-Allow-Origin': '*', "Content-Type": "video/mp2t",
+									 "Content-Disposition": "inline", "Content-Transfer-Enconding": "binary"})
 		return response
-		# return redirect(url, code=302)
 
+
+# return redirect(url, code=302)
 
 ############################################################
 # MAIN
@@ -3551,7 +3733,7 @@ def main():
 
 	logger.info("Building initial playlist...")
 	try:
-		global chan_map, FALLBACK, CHANAPI, jsonGuide1, jsonGuide2, playlist, kodiplaylist, tvhplaylist
+		global chan_map, FALLBACK, CHANAPI, jsonGuide1, jsonGuide2, playlist, kodiplaylist, tvhplaylist, sportsPlaylist
 		# fetch chan_map
 		try:
 			chan_map = build_channel_map()
@@ -3569,6 +3751,7 @@ def main():
 		jsonGuide2 = getJSON("tv.json", "https://iptvguide.netlify.com/tv.json",
 							 "https://fast-guide.smoothstreams.tv/altepg/feedall1.json")
 		playlist = build_playlist(SERVER_HOST)
+		sportsPlaylist = build_sports_playlist(SERVER_HOST)
 		kodiplaylist = build_kodi_playlist()
 		tvhplaylist = build_tvh_playlist()
 
@@ -3611,7 +3794,7 @@ def main():
 	if __version__ < latest_ver:
 		logger.info(
 			"Your version (%s%s) is out of date, the latest is %s, which has now be downloaded for you into the 'updates' subdirectory." % (
-			type, __version__, latest_ver))
+				type, __version__, latest_ver))
 		newfilename = ntpath.basename(latestfile)
 		if not os.path.isdir(os.path.join(os.path.dirname(sys.argv[0]), 'updates')):
 			os.mkdir(os.path.join(os.path.dirname(sys.argv[0]), 'updates'))
@@ -3634,6 +3817,7 @@ def main():
 		os.system('cls' if os.name == 'nt' else 'clear')
 		logger.exception("Proxy failed to launch, try another port")
 	logger.info("Finished!")
+
 
 if __name__ == "__main__":
 	main()


### PR DESCRIPTION
Added a new command line parameter  `--cloud` that controls behavior when being hosted in a cloud environment and used from clients outside the LAN range where the script runs.

This will make the web interface usable from the outside, as well as making channel playlists remove the currently non-obligatory query parameter `nimblesessionid` from URLs as it is responsible for checking that the original authenticating IP matches the one that requests the stream - Which is different in this scenario.